### PR TITLE
Fix examples/call/cocotb/call_sv_bfm

### DIFF
--- a/examples/call/cocotb/call_sv_bfm/call_sv_bfm.py
+++ b/examples/call/cocotb/call_sv_bfm/call_sv_bfm.py
@@ -38,7 +38,7 @@ async def entry(dut):
         await init_bfm.write(0x8000_0000+(4*i), wr_val)
         rd = await init_bfm.read(0x8000_0000+(4*i))
         print(f'[Py] readback: {rd}')
-        assert wr_val == rd
+        assert wr_val == rd.parent.data
 
     for i in range(64):
         await init_bfm.read(0x8000_0000+(4*i))


### PR DESCRIPTION
Using the setup instructions in the repository and in the example directory, this test fails out of the box due to the fact that `await init_bfm.read()` returns a `cocotb.triggers._Event` and not an `int`. The solution for this is accessing the event's parent data.

This resolves #22. The solution offered in that thread does fix this test as well, but it breaks other unit tests.